### PR TITLE
Fix status endpoint

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -144,13 +144,13 @@ func (d *Database) GetValidatorStatus(network string, pubkey beacon.ValidatorPub
 	// Check if the StakeWise vault has already seen it
 	for _, vault := range vaults {
 		if vault.Address == validator.VaultAddress && vault.UploadedData[validator.Pubkey] {
-			return api.StakeWiseStatus_Uploaded
+			return api.StakeWiseStatus_Registered
 		}
 	}
 
 	// Check to see if the deposit data has been used
 	if validator.DepositDataUsed {
-		return api.StakeWiseStatus_Uploading
+		return api.StakeWiseStatus_Uploaded
 	}
 	return api.StakeWiseStatus_Pending
 }


### PR DESCRIPTION
```

Uploaded to NS and SW but not registered with SW yet (NYI)
Yeah, this corresponds to UPLOADED

Uploaded to NS and SW, and registered with SW (NYI)
Corresponds to  REGISTERED

```